### PR TITLE
fix: replace browser base64 with node buffer

### DIFF
--- a/backend/auth/auth.ts
+++ b/backend/auth/auth.ts
@@ -1,6 +1,7 @@
 import { Header, APIError, Gateway } from "encore.dev/api";
 import { authHandler } from "encore.dev/auth";
 import type { AuthData } from "./types";
+import { base64Decode } from "./base64";
 
 // Simple JWT verification without external dependencies
 function verifySimpleJWT(token: string): any {
@@ -10,7 +11,7 @@ function verifySimpleJWT(token: string): any {
       throw new Error("Invalid token format");
     }
     
-    const payload = JSON.parse(atob(parts[1]));
+    const payload = JSON.parse(base64Decode(parts[1]));
     
     // Check expiration
     if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {

--- a/backend/auth/base64.ts
+++ b/backend/auth/base64.ts
@@ -1,0 +1,7 @@
+export function base64Encode(data: string): string {
+  return Buffer.from(data, "utf8").toString("base64");
+}
+
+export function base64Decode(data: string): string {
+  return Buffer.from(data, "base64").toString("utf8");
+}

--- a/backend/auth/login.ts
+++ b/backend/auth/login.ts
@@ -1,15 +1,16 @@
 import { api, APIError } from "encore.dev/api";
 import type { LoginRequest, LoginResponse, User } from "./types";
+import { base64Encode } from "./base64";
 
 // Simple JWT implementation without external dependencies
 function createSimpleJWT(payload: any): string {
   const header = { alg: "HS256", typ: "JWT" };
-  const encodedHeader = btoa(JSON.stringify(header));
-  const encodedPayload = btoa(JSON.stringify(payload));
-  
+  const encodedHeader = base64Encode(JSON.stringify(header));
+  const encodedPayload = base64Encode(JSON.stringify(payload));
+
   // Simple signature using a hardcoded secret for demo purposes
-  const signature = btoa(`${encodedHeader}.${encodedPayload}.demo-secret`);
-  
+  const signature = base64Encode(`${encodedHeader}.${encodedPayload}.demo-secret`);
+
   return `${encodedHeader}.${encodedPayload}.${signature}`;
 }
 

--- a/backend/auth/verify.ts
+++ b/backend/auth/verify.ts
@@ -1,5 +1,6 @@
 import { api, APIError } from "encore.dev/api";
 import type { User } from "./types";
+import { base64Decode } from "./base64";
 
 // Simple JWT verification without external dependencies
 function verifySimpleJWT(token: string): any {
@@ -9,7 +10,7 @@ function verifySimpleJWT(token: string): any {
       throw new Error("Invalid token format");
     }
     
-    const payload = JSON.parse(atob(parts[1]));
+    const payload = JSON.parse(base64Decode(parts[1]));
     
     // Check expiration
     if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {


### PR DESCRIPTION
## Summary
- use Buffer-based helpers instead of btoa/atob for JWT auth

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p backend --noEmit` (fails: Cannot find module '~encore/auth' or its corresponding type declarations)


------
https://chatgpt.com/codex/tasks/task_e_68a03e9a29208328852cede75a20070a