### PR TITLE
fix: resolve client type errors

### DIFF
--- a/backend/auth/auth.ts
+++ b/backend/auth/auth.ts
@@ -7,7 +7,7 @@ interface AuthParams {
   authorization?: Header<"Authorization">;
 }
 
-const auth = authHandler<AuthParams, AuthData>(async (data) => {
+export const auth = authHandler<AuthParams, AuthData>(async (data) => {
   const token = data.authorization?.replace("Bearer ", "");
   if (!token) {
     throw APIError.unauthenticated("missing token");

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,6 +17,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "types": [
+      "vite/client"
+    ],
     "baseUrl": ".",
     "paths": {
       "@/*": [
@@ -27,6 +30,9 @@
       ],
       "~backend/client": [
         "./client.ts"
+      ],
+      "~encore/*": [
+        "../backend/encore.gen/*"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- export backend auth handler
- add Vite client types and Encore alias to frontend tsconfig

## Testing
- `bunx tsc -p backend/tsconfig.json --noEmit`
- `bunx tsc -p frontend/tsconfig.json --noEmit`
- `cd backend && bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0509e93748328b1f3caba25969a78