### PR TITLE
fix ts config for frontend and auth export

### DIFF
--- a/backend/auth/auth.ts
+++ b/backend/auth/auth.ts
@@ -7,7 +7,7 @@ interface AuthParams {
   authorization?: Header<"Authorization">;
 }
 
-const auth = authHandler<AuthParams, AuthData>(async (data) => {
+export const auth = authHandler<AuthParams, AuthData>(async (data) => {
   const token = data.authorization?.replace("Bearer ", "");
   if (!token) {
     throw APIError.unauthenticated("missing token");

--- a/frontend/env.d.ts
+++ b/frontend/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_CLIENT_TARGET: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -27,12 +27,16 @@
       ],
       "~backend/client": [
         "./client.ts"
+      ],
+      "~encore/*": [
+        "../backend/encore.gen/*"
       ]
     }
   },
   "include": [
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    "env.d.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- export auth handler from backend
- add ~encore alias and env typings to frontend

## Testing
- `bunx tsc --noEmit` (backend)
- `bunx tsc --noEmit` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68a05bb756e483288243447257895fe7